### PR TITLE
Add support for Windows agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ inputs:
 
 ## Usage
 
+### Linux
+
 ```yaml
 name: SAST
 on:
@@ -40,6 +42,41 @@ jobs:
         - name: Install dependencies
           run: |
             dotnet restore
+
+        - name: Static application security testing
+          uses: visma-prodsec/coverity-on-polaris-workflow@v1
+          with:
+            api_url: ${{ vars.COVERITY_ON_POLARIS_API_URL }}
+            access_token: ${{ secrets.COVERITY_ON_POLARIS_ACCESS_TOKEN }}
+```
+
+### Windows
+
+```yaml
+name: SAST
+on:
+  workflow_dispatch:
+  workflow_call:
+  schedule:
+    - cron: "0 12 * * *" # Runs at 12:00 everyday
+
+env:
+  DOTNET_NOLOGO: 1
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+
+jobs:
+  analyze:
+    name: Capture and send
+    runs-on: windows-latest
+    steps:
+        - name: Checkout repo
+          uses: actions/checkout@v3
+
+        - name: Setup MSBuild.exe
+          uses: microsoft/setup-msbuild@v1.1
+
+        - name: Install dependencies
+          run: dotnet restore
 
         - name: Static application security testing
           uses: visma-prodsec/coverity-on-polaris-workflow@v1

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,27 @@ runs:
         echo Removing Polaris CLI
         rm -rf /tmp/polari_cli
 
+    - if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        DOTNET_NOLOGO: 1
+        DOTNET_CLI_TELEMETRY_OPTOUT: 1
+        POLARIS_ACCESS_TOKEN: ${{ inputs.access_token }}
+      run: |
+        Write-Host "Downloading Polaris CLI"
+        $polarisCliZipPath = Join-Path $env:TEMP "polaris_cli-win64.zip"
+        Invoke-WebRequest -Uri "${{ inputs.api_url }}/api/tools/v2/downloads/polaris_cli-win64.zip" -OutFile $polarisCliZipPath
+
+        Write-Host "Unzipping Polaris CLI"
+        $polarisCliUnzipPath = Join-Path $env:TEMP "polaris_cli"
+        Expand-Archive -Path $polarisCliZipPath -DestinationPath $polarisCliUnzipPath
+
+        Write-Host "Running Polaris Analysis"
+        & (Get-ChildItem -Path $polarisCliUnzipPath -Recurse -Filter polaris.exe | Select-Object -First 1).FullName analyze --upload-local-config
+
+        Write-Host "Removing Polaris CLI"
+        Remove-Item -Recurse -Force $polarisCliUnzipPath
+
 branding:
   icon: 'shield'
   color: 'purple'


### PR DESCRIPTION
I had to add support for building on Windows since we have one repo with a legacy .NET Framework app. So, here are the changes required, in case you are interested.